### PR TITLE
Permite restaurar resoluciones despublicadas

### DIFF
--- a/app/Http/Controllers/ResolucionController.php
+++ b/app/Http/Controllers/ResolucionController.php
@@ -154,11 +154,14 @@ public function store(Request $request)
 public function destroy($id)
 {
     $resolucion = Resolucion::findOrFail($id);
-    $resolucion->mostrar_res = 0;
-    $resolucion->save();
+    $resolucion->update([
+        'mostrar_res' => 0,
+        'fecha_mod_res' => now(),
+    ]);
 
-    return redirect()->route('resoluciones.index')
-                     ->with('success', 'Resolución eliminada correctamente (borrado lógico).');
+    return redirect()
+        ->route('resoluciones.index')
+        ->with('success', 'Resolución eliminada correctamente (borrado lógico).');
 }
 
 public function eliminadas()
@@ -174,11 +177,14 @@ public function eliminadas()
 public function restaurar($id)
 {
     $resolucion = Resolucion::findOrFail($id);
-    $resolucion->mostrar_res = 1;
-    $resolucion->save();
+    $resolucion->update([
+        'mostrar_res' => 1,
+        'fecha_mod_res' => now(),
+    ]);
 
-    return redirect()->route('resoluciones.eliminadas')
-                     ->with('success', 'Resolución restaurada correctamente.');
+    return redirect()
+        ->route('resoluciones.eliminadas')
+        ->with('success', 'Resolución restaurada correctamente.');
 }
 
 


### PR DESCRIPTION
## Summary
- Actualiza controlador para registrar fecha de modificación al eliminar o restaurar resoluciones
- Conserva listado de resoluciones despublicadas con opción de restaurar

## Testing
- `php artisan test` *(falla: requiere vendor/autoload.php)*
- `composer install` *(falla: nette/schema requiere PHP 7.1 - 8.3)*

------
https://chatgpt.com/codex/tasks/task_e_68bed1995e3c8333b8c59d1b48944593